### PR TITLE
Fix incorrect disk_info usage of API and ApiWrapper classes

### DIFF
--- a/lib/ffi-vix_disk_lib/version.rb
+++ b/lib/ffi-vix_disk_lib/version.rb
@@ -1,5 +1,5 @@
 module FFI
   module VixDiskLib
-    VERSION = "1.0.1"
+    VERSION = "1.0.0"
   end
 end


### PR DESCRIPTION
Fix the usage of the Geometry structure from struct.rb as well
as call to the get_info method in the api.rb - both in the API class.

@Fryguy @roliveri please review
