### PR TITLE
Remove 5.1.0 from bad_versions

### DIFF
--- a/lib/ffi-vix_disk_lib/api.rb
+++ b/lib/ffi-vix_disk_lib/api.rb
@@ -19,7 +19,7 @@ module FFI
       # Make sure we load one and only one version of VixDiskLib
       #
       version_load_order = %w( 5.5.2 5.5.1 5.5.0 5.1.3 5.1.2 5.1.1 5.1.0 5.0.4 5.0.0 1.2.0 1.1.2 )
-      bad_versions       = {"5.1.0" => "Disk Open May Core Dump without an SSL Thumbprint"}
+      bad_versions       = {}
       load_errors        = []
       loaded_library     = ""
       version_load_order.each do |version|


### PR DESCRIPTION
Remove the 5.1.0 release of vddk from the list of unsupported versions.
VMware has stopped shipping the vddk with patch releases other than ".0"
They ship some versions as 5.1.0 update N, and some versions as 5.1.x
where x is a non-zero number, but the .so library files will have the
"5.1.0" suffix in all cases.  The code checking the supported versions
can only be used going forward if we stop supporting an entire point release.

https://bugzilla.redhat.com/show_bug.cgi?id=1151465

@roliveri @Fryguy @chessbyte @jrafanie please review.