### PR TITLE
Vddk6.0 support

### DIFF
--- a/lib/ffi-vix_disk_lib/api.rb
+++ b/lib/ffi-vix_disk_lib/api.rb
@@ -18,7 +18,7 @@ module FFI
       #
       # Make sure we load one and only one version of VixDiskLib
       #
-      version_load_order = %w( 5.5.2 5.5.1 5.5.0 5.1.3 5.1.2 5.1.1 5.1.0 5.0.4 5.0.0 1.2.0 1.1.2 )
+      version_load_order = %w( 6.0.0 5.5.4 5.5.2 5.5.1 5.5.0 5.1.3 5.1.2 5.1.1 5.1.0 5.0.4 5.0.0 1.2.0 1.1.2 )
       bad_versions       = {}
       load_errors        = []
       loaded_library     = ""

--- a/lib/ffi-vix_disk_lib/safe_connect_params.rb
+++ b/lib/ffi-vix_disk_lib/safe_connect_params.rb
@@ -37,6 +37,7 @@ module FFI
         get_safe_creds(cred_type, in_conn_parms, @connect_params + API::ConnectParams.offset_of(:creds))
         conn_parms      = @connect_params + API::ConnectParams.offset_of(:port)
         conn_parms.write_uint32(in_conn_parms[:port]) unless in_conn_parms[:port].nil?
+        conn_parms.write_uint32(0) if API::VERSION_MAJOR > 5
         @connect_params
       end
 


### PR DESCRIPTION
Add support for VixDiskLib release 6.0.0.  This gem should obviously continue working with prior releases of VixDiskLib as well.

@Fryguy @roliveri please review.