### PR TITLE
Use different ConnectParams based on version

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,4 @@
+--require spec_helper
+--color
+--order random
+--format documentation

--- a/lib/ffi-vix_disk_lib/api.rb
+++ b/lib/ffi-vix_disk_lib/api.rb
@@ -26,6 +26,7 @@ module FFI
         begin
           loaded_library = ffi_lib ["vixDiskLib.so.#{version}"]
           VERSION_MAJOR, VERSION_MINOR = loaded_library.first.name.split(".")[2, 2].collect(&:to_i)
+          VERSION = version
           if bad_versions.keys.include?(version)
             loaded_library = ""
             @load_error = "VixDiskLib #{version} is not supported: #{bad_versions[version]}"
@@ -60,6 +61,17 @@ module FFI
       def self.vix_failed?(err)
         err != VixErrorType[:VIX_OK]
       end
+
+      def self.evaluate_versioned_connect_params
+        case VERSION
+        when "6.5.0"
+          ConnectParams_6_5_0
+        else
+          ConnectParams_1_0_0
+        end
+      end
+
+      ConnectParams = evaluate_versioned_connect_params
 
       callback :GenericLogFunc, [:string, :pointer], :void
 

--- a/lib/ffi-vix_disk_lib/struct.rb
+++ b/lib/ffi-vix_disk_lib/struct.rb
@@ -57,14 +57,26 @@ module FFI
       #
       # Example VM spec:
       # "MyVm/MyVm.vmx?dcPath=Path/to/MyDatacenter&dsName=storage1"
-      class ConnectParams < FFI::Struct
-        layout :vmxSpec,    :pointer,
-               :serverName, :pointer,
-               :thumbPrint, :pointer,
-               :privateUse, :long,
+      class ConnectParams_1_0_0 < FFI::Struct
+        layout :vmxSpec,    :pointer, # URL like spec of the VM.
+               :serverName, :pointer, # Name or IP address of VC / ESX.
+               :thumbPrint, :pointer, # SSL Certificate thumb print.
+               :privateUse, :long,    # This value is ignored.
                :credType,   CredType,
                :creds,      Creds,
-               :port,       :uint32
+               :port,       :uint32   # port to use for authenticating with VC/ESXi host
+      end
+
+      class ConnectParams_6_5_0 < FFI::Struct
+        layout :vmxSpec,     :pointer, # URL like spec of the VM.
+               :serverName,  :pointer, # Name or IP address of VC / ESX.
+               :thumbPrint,  :pointer, # SSL Certificate thumb print.
+               :privateUse,  :long,    # This value is ignored.
+               :credType,    CredType,
+               :creds,       Creds,
+               :port,        :uint32,  # port to use for authenticating with VC/ESXi host
+               :nfcHostPort, :uint32,  # port to use for establishing NFC connection to ESXi host
+               :vimApiVer,   :pointer  # VIM API version to use, private
       end
 
       class Info < FFI::Struct

--- a/spec/ffi-vix_disk_lib/api_spec.rb
+++ b/spec/ffi-vix_disk_lib/api_spec.rb
@@ -1,0 +1,13 @@
+describe FFI::VixDiskLib::API do
+  let(:major_version) { described_class::VERSION_MAJOR }
+  let(:minor_version) { described_class::VERSION_MINOR }
+  let(:log)           { lambda { |_string, _pointer| } }
+  let(:lib_dir)       { nil }
+
+  context "init" do
+    it "initializes successfully" do
+      err = described_class.init(major_version, minor_version, log, log, log, lib_dir)
+      expect(err).to eq(described_class::VixErrorType[:VIX_OK])
+    end
+  end
+end

--- a/spec/ffi-vix_disk_lib/api_wrapper_spec.rb
+++ b/spec/ffi-vix_disk_lib/api_wrapper_spec.rb
@@ -1,0 +1,15 @@
+require 'ffi-vix_disk_lib/api_wrapper'
+
+describe FFI::VixDiskLib::ApiWrapper do
+  context "connect" do
+    before do
+      described_class.init
+    end
+
+    it "returns a connection" do
+      connect_params = {}
+      connection = described_class.connect(connect_params)
+      expect(connection).not_to be_nil
+    end
+  end
+end

--- a/spec/ffi-vix_disk_lib/version_spec.rb
+++ b/spec/ffi-vix_disk_lib/version_spec.rb
@@ -1,0 +1,5 @@
+describe FFI::VixDiskLib::VERSION do
+  it "must be defined" do
+    expect(FFI::VixDiskLib::VERSION).to_not be_nil
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,3 @@
-require 'minitest'
-require 'minitest/autorun'
-
 begin
   require 'ffi-vix_disk_lib'
 rescue LoadError
@@ -14,4 +11,7 @@ See https://www.vmware.com/support/developer/vddk/ for more information.
 EOMSG
 
   exit 1
+end
+
+RSpec.configure do |config|
 end

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -1,7 +1,0 @@
-require_relative './spec_helper'
-
-describe FFI::VixDiskLib::VERSION do
-  it "must be defined" do
-    FFI::VixDiskLib::VERSION.wont_be_nil
-  end
-end


### PR DESCRIPTION
A vimApiVer was added in 6.5 and causes segfaults if it is unset.

This will check the version of the library which was loaded and evaluate
the ConnectParams class for that version.

https://bugzilla.redhat.com/show_bug.cgi?id=1527658