### PR TITLE
Support VDDK 6.7

### DIFF
--- a/lib/ffi-vix_disk_lib/api.rb
+++ b/lib/ffi-vix_disk_lib/api.rb
@@ -18,7 +18,7 @@ module FFI
       #
       # Make sure we load one and only one version of VixDiskLib
       #
-      version_load_order = %w( 6.5.0 6.0.0 5.5.4 5.5.2 5.5.1 5.5.0 5.1.3 5.1.2 5.1.1 5.1.0 5.0.4 5.0.0 1.2.0 1.1.2 )
+      version_load_order = %w( 6.7.0 6.5.0 6.0.0 5.5.4 5.5.2 5.5.1 5.5.0 5.1.3 5.1.2 5.1.1 5.1.0 5.0.4 5.0.0 1.2.0 1.1.2 )
       bad_versions       = {}
       load_errors        = []
       loaded_library     = ""


### PR DESCRIPTION
Modify this gem to allow support for the 6.7 VDDK from VmWare.  Marking as WIP until a test bed has been made available to us to validate.

This will allow SSA to succeed on a 6.7 VSphere using a 6.7 VDDK.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1651702

@roliveri FYI.