### PR TITLE
Allow gem to be loaded even if the VDDK is not found

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,7 @@
 #!/usr/bin/env rake
 require "bundler/gem_tasks"
 
-require 'rake/testtask'
-
-Rake::TestTask.new do |t|
-  t.test_files = FileList['spec/**/*_spec.rb']
-  t.verbose = true
-end
-
-task :spec => :test
-task :default => :test
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new('spec')
+task :test => :spec
+task :default => :spec

--- a/ffi-vix_disk_lib.gemspec
+++ b/ffi-vix_disk_lib.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "minitest"
+  spec.add_development_dependency "rspec"
 
   spec.add_dependency "ffi"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
-begin
-  require 'ffi-vix_disk_lib'
-rescue LoadError
+require 'ffi-vix_disk_lib'
+
+unless FFI::VixDiskLib::API.available?
   STDERR.puts <<-EOMSG
 
 The VMware VDDK must be installed in order to run specs.
@@ -9,7 +9,6 @@ The VMware VDDK is not redistributable, and not available on MacOSX.
 See https://www.vmware.com/support/developer/vddk/ for more information.
 
 EOMSG
-
   exit 1
 end
 


### PR DESCRIPTION
- Add FFI::VixDiskLib::API.available? method to allow for checking
whether or not the VDDK is available.

@agrare Please review.