### PR TITLE
Simplify loading of the dynamic library and make it work on Mac

### DIFF
--- a/spec/ffi-vix_disk_lib/api_spec.rb
+++ b/spec/ffi-vix_disk_lib/api_spec.rb
@@ -1,17 +1,27 @@
 describe FFI::VixDiskLib::API do
-  let(:major_version) { described_class::VERSION_MAJOR }
-  let(:minor_version) { described_class::VERSION_MINOR }
-  let(:log)           { lambda { |_string, _pointer| } }
-  let(:lib_dir)       { nil }
+  let(:log)     { lambda { |_string, _pointer| } }
+  let(:lib_dir) { nil }
 
-  context "init" do
+  it "VERSION" do
+    expect(described_class::VERSION).to eq "6.7.0"
+  end
+
+  it "VERSION_MAJOR" do
+    expect(described_class::VERSION_MAJOR).to eq 6
+  end
+
+  it "VERSION_MINOR" do
+    expect(described_class::VERSION_MINOR).to eq 7
+  end
+
+  describe ".init" do
     it "initializes successfully" do
-      err = described_class.init(major_version, minor_version, log, log, log, lib_dir)
+      err = described_class.init(described_class::VERSION_MAJOR, described_class::VERSION_MINOR, log, log, log, lib_dir)
       expect(err).to eq(described_class::VixErrorType[:VIX_OK])
     end
   end
 
-  context "ConnectParams" do
+  describe "ConnectParams" do
     case described_class::VERSION
     when "6.5.0"
       it "has vimApiVer" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,17 +1,6 @@
-begin
-  require 'ffi-vix_disk_lib'
-rescue LoadError
-  STDERR.puts <<-EOMSG
+ENV["LD_LIBRARY_PATH"] ||= File.expand_path("ext", __dir__)
 
-The VMware VDDK must be installed in order to run specs.
-
-The VMware VDDK is not redistributable, and not available on MacOSX.
-See https://www.vmware.com/support/developer/vddk/ for more information.
-
-EOMSG
-
-  exit 1
-end
+require 'ffi-vix_disk_lib'
 
 RSpec.configure do |config|
 end


### PR DESCRIPTION
@agrare Please review.

This change simplifies the loading by using the fact that ffi_lib can try multiple libraries.  Note that on Mac, LD_LIBRARY_PATH is ignored, so to allow it for testing, we have to hack in path manipulation.  This should not affect Linux OSes.