### PR TITLE
Fix missing API.load_error method

### DIFF
--- a/lib/ffi-vix_disk_lib/api.rb
+++ b/lib/ffi-vix_disk_lib/api.rb
@@ -11,6 +11,14 @@ module FFI
         warn "unable to attach #{args.first}"
       end
 
+      #
+      # Maintain backwards compatibility with the previous method
+      # of loading libvixDiskLib
+      #
+      def self.load_error
+        nil
+      end
+
       candidate_versions  = %w[6.7.0 6.5.0 6.0.0 5.5.4 5.5.2 5.5.1 5.5.0 5.1.3 5.1.2 5.1.1 5.1.0 5.0.4 5.0.0 1.2.0 1.1.2]
       candidate_libraries = candidate_versions.map { |v| "vixDiskLib.so.#{v}" }
 


### PR DESCRIPTION
Previously there was a .load_error method which returned the exceptions
which were caught while loading libvixDiskLib.  Now the LoadError is
raised normally so this method isn't needed but has to be present for
backwards compatibility.