### PR TITLE
Drop old VDDK library versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,8 +17,11 @@ jobs:
         - '2.7'
         - '3.0'
         vddk-version:
-        - '5.5.0'
+        - '6.0.0'
+        - '6.5.0'
         - '6.7.0'
+        - '7.0.0'
+        - '8.0.0'
     env:
       LD_LIBRARY_PATH: spec/ext
       VDDK_VERSION: ${{ matrix.vddk-version }}

--- a/lib/ffi-vix_disk_lib/api.rb
+++ b/lib/ffi-vix_disk_lib/api.rb
@@ -19,7 +19,7 @@ module FFI
         nil
       end
 
-      candidate_versions  = %w[8.0.0 7.0.3 7.0.2 7.0.1 7.0.0 6.7.3 6.7.2 6.7.1 6.7.0 6.5.4 6.5.3 6.5.2 6.5.1 6.5.0 6.0.3 6.0.2 6.0.1 6.0.0 5.5.4 5.5.2 5.5.1 5.5.0 5.1.3 5.1.2 5.1.1 5.1.0 5.0.4 5.0.0 1.2.0 1.1.2]
+      candidate_versions  = %w[8.0.0 7.0.3 7.0.2 7.0.1 7.0.0 6.7.3 6.7.2 6.7.1 6.7.0 6.5.4 6.5.3 6.5.2 6.5.1 6.5.0 6.0.3 6.0.2 6.0.1 6.0.0]
       candidate_libraries = candidate_versions.map { |v| "vixDiskLib.so.#{v}" }
 
       # LD_LIBRARY_PATH/DYLD_LIBRARY_PATH is not passed to child process on a Mac with SIP


### PR DESCRIPTION
Built on top of #22 
- VDDK versions < 5.1 are not available for download anymore
- vCenter 5.1 end of technical guidance was 2018-08-24
- vCenter 5.5 end of technical guidance was 2020-09-19

For reference: https://lifecycle.vmware.com/#/