### PR TITLE
Add VDDK v8.0.3 support

### DIFF
--- a/lib/ffi-vix_disk_lib/api.rb
+++ b/lib/ffi-vix_disk_lib/api.rb
@@ -19,7 +19,7 @@ module FFI
         nil
       end
 
-      candidate_versions  = %w[8.0.2 8.0.1 8.0.0 7.0.3 7.0.2 7.0.1 7.0.0 6.7.3 6.7.2 6.7.1 6.7.0 6.5.4 6.5.3 6.5.2 6.5.1 6.5.0 6.0.3 6.0.2 6.0.1 6.0.0]
+      candidate_versions  = %w[8.0.3 8.0.2 8.0.1 8.0.0 7.0.3 7.0.2 7.0.1 7.0.0 6.7.3 6.7.2 6.7.1 6.7.0 6.5.4 6.5.3 6.5.2 6.5.1 6.5.0 6.0.3 6.0.2 6.0.1 6.0.0]
       candidate_libraries = candidate_versions.map { |v| "vixDiskLib.so.#{v}" }
 
       # LD_LIBRARY_PATH/DYLD_LIBRARY_PATH is not passed to child process on a Mac with SIP


### PR DESCRIPTION
Add VDDK 8.0.3 as a supported version, https://docs.vmware.com/en/VMware-vSphere/8.0/rn/vddk-803-release-notes.html
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
