### PR TITLE
Fix gem build including bin/bin/setup

### DIFF
--- a/ffi-vix_disk_lib.gemspec
+++ b/ffi-vix_disk_lib.gemspec
@@ -15,8 +15,6 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -- lib/*`.split("\n")
   spec.files        += %w(README.md LICENSE.txt)
-  spec.executables   = `git ls-files -- bin/*`.split("\n")
-  spec.test_files    = `git ls-files -- spec/*`.split("\n")
   spec.require_paths = ["lib"]
 
   spec.add_dependency "ffi"


### PR DESCRIPTION
```
adam@workstation:~/src/manageiq/ffi-vix_disk_lib$ gem build
WARNING:  See https://guides.rubygems.org/specification-reference/ for help
ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
    ["bin/bin/setup"] are not files
	/usr/lib/ruby/vendor_ruby/rubygems/specification_policy.rb:500:in `error'
	/usr/lib/ruby/vendor_ruby/rubygems/specification_policy.rb:303:in `validate_non_files'
	/usr/lib/ruby/vendor_ruby/rubygems/specification_policy.rb:75:in `validate_required!'
	/usr/lib/ruby/vendor_ruby/rubygems/specification_policy.rb:46:in `validate'
	/usr/lib/ruby/vendor_ruby/rubygems/specification.rb:2647:in `validate'
	/usr/lib/ruby/vendor_ruby/rubygems/package.rb:299:in `build'
	/usr/lib/ruby/vendor_ruby/rubygems/package.rb:137:in `build'
	/usr/lib/ruby/vendor_ruby/rubygems/commands/build_command.rb:103:in `build_package'
	/usr/lib/ruby/vendor_ruby/rubygems/commands/build_command.rb:93:in `build_gem'
	/usr/lib/ruby/vendor_ruby/rubygems/commands/build_command.rb:73:in `execute'
	/usr/lib/ruby/vendor_ruby/rubygems/command.rb:328:in `invoke_with_build_args'
	/usr/lib/ruby/vendor_ruby/rubygems/command_manager.rb:253:in `invoke_command'
	/usr/lib/ruby/vendor_ruby/rubygems/command_manager.rb:193:in `process_args'
	/usr/lib/ruby/vendor_ruby/rubygems/command_manager.rb:151:in `run'
	/usr/lib/ruby/vendor_ruby/rubygems/gem_runner.rb:52:in `run'
	/usr/bin/gem:12:in `<main>'
```

With these changes this is the content of `spec.files`: `LICENSE.txt, README.md, lib/ffi-vix_disk_lib.rb, lib/ffi-vix_disk_lib/api.rb, lib/ffi-vix_disk_lib/api_wrapper.rb, lib/ffi-vix_disk_lib/const.rb, lib/ffi-vix_disk_lib/disk_info.rb, lib/ffi-vix_disk_lib/enum.rb, lib/ffi-vix_disk_lib/exceptions.rb, lib/ffi-vix_disk_lib/libc.rb, lib/ffi-vix_disk_lib/safe_connect_params.rb, lib/ffi-vix_disk_lib/safe_create_params.rb, lib/ffi-vix_disk_lib/struct.rb, lib/ffi-vix_disk_lib/version.rb`

And `gem build` is success
```
$ gem build
WARNING:  description and summary are identical
WARNING:  open-ended dependency on ffi (>= 0) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on bundler (>= 0, development) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on manageiq-style (>= 0, development) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on rake (>= 0, development) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on rspec (>= 0, development) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on simplecov (>= 0.21.2, development) is not recommended
  if simplecov is semantically versioned, use:
    add_development_dependency 'simplecov', '~> 0.21', '>= 0.21.2'
WARNING:  See https://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: ffi-vix_disk_lib
  Version: 1.3.1
  File: ffi-vix_disk_lib-1.3.1.gem
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
